### PR TITLE
fix: extend page data on wrong pages (fix #32)

### DIFF
--- a/src/node/handleOptions.ts
+++ b/src/node/handleOptions.ts
@@ -99,10 +99,20 @@ export function handleOptions(
      * 1.3 Set layout for pages that match current directory classifier.
      */
     pageEnhancers.push({
-      when: ({ regularPath }) =>
-        Boolean(regularPath) &&
-        regularPath !== indexPath &&
-        regularPath.startsWith(`/${dirname}/`),
+      /**
+       * Exclude index pages
+       * Exclude pagination pages
+       * Pick pages matched directory name
+       */
+      filter({ regularPath }) {
+        const regex = new RegExp(`^/${dirname}/page/\\d+/`);
+        return (
+          Boolean(regularPath) &&
+          regularPath !== indexPath &&
+          !regex.test(regularPath) &&
+          regularPath.startsWith(`/${dirname}/`)
+        );
+      },
       frontmatter: {
         layout: ctx.getLayout(itemLayout, 'Post'),
         permalink: itemPermalink,

--- a/src/node/index.ts
+++ b/src/node/index.ts
@@ -90,10 +90,10 @@ module.exports = (options: BlogPluginOptions, ctx: VuePressContext) => {
      * 1. Execute `pageEnhancers` generated in handleOptions
      */
     extendPageData(pageCtx: VuePressPage) {
-      const { frontmatter: rawFrontmatter } = pageCtx;
+      pageEnhancers.forEach(({ filter, data = {}, frontmatter = {} }) => {
+        const { frontmatter: rawFrontmatter } = pageCtx;
 
-      pageEnhancers.forEach(({ when, data = {}, frontmatter = {} }) => {
-        if (when(pageCtx)) {
+        if (filter(pageCtx)) {
           Object.keys(frontmatter).forEach(key => {
             /**
              * Respect the original frontmatter in markdown

--- a/src/node/interface/PageEnhancer.ts
+++ b/src/node/interface/PageEnhancer.ts
@@ -4,7 +4,7 @@ export interface PageEnhancer {
   /**
    * Conditions for enhancer execution
    */
-  when($page: VuePressPage): boolean;
+  filter($page: VuePressPage): boolean;
 
   /**
    * frontmatter injected to matched pages


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**

`vuepress-plugin-blog` will leverage [extendpagedata](https://vuepress.vuejs.org/plugin/option-api.html#extendpagedata) to enhance post pages. But it occasionally extend page data on pagination pages. see #32.

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

If changing the UI of default theme, please provide the **before/after** screenshot:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

You have tested in the following browsers: (Providing a detailed version will be better.)

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
- [ ] IE

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature
- [ ] Related documents have been updated
- [ ] Related tests have been updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
