### PR TITLE
fix: default sorter doesn't work fine in Safari

### DIFF
--- a/docs/pagination/README.md
+++ b/docs/pagination/README.md
@@ -17,12 +17,16 @@ Sorter for matched pages, the default sorter is as follows:
 
 ```typescript
 function sorter(prev: VuePressPage, next: VuePressPage){
-  const prevTime = new Date(prev.frontmatter.date).getTime()
-  const nextTime = new Date(next.frontmatter.date).getTime()
+  const prevTime = new Date(prev.frontmatter.date.replace(/\-/g, '/')).getTime()
+  const nextTime = new Date(next.frontmatter.date.replace(/\-/g, '/')).getTime()
   return prevTime - nextTime > 0 ? -1 : 1
 },
 ```
 The function will be a parameter of [Array.sort()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort).
+
+::: warning Note
+You might be intrigued by `replace(/\-/g, '/')`. Because only the dates in frontmatter written in 2-digits will be transformed, other dates written in single-digit, such as `2020-1-1` will be treated as string. Some browsers (e.g. Safari) don't support this format.
+:::
 
 ## lengthPerPage
 
@@ -83,7 +87,7 @@ There are three args to help you customize your title:
 - `id` is the id in the [config](../config/#id).
 - `scope` is the [key](../config/#keys) while configuring frontmatters or same as `id` while configuring directories.
 
-::: tip TIP
+::: warning Note
 `${index + 2}`: why `+2`?
 
 Plus 1 since index starts at 0. <br>

--- a/src/node/util.ts
+++ b/src/node/util.ts
@@ -108,9 +108,19 @@ export function resolvePaginationConfig(
             }
           : getFrontmatterClassifierPageFilter(keys),
 
+      /**
+       * You might be intrigued by `replace(/\-/g, '/')`.
+       * Because only the dates in frontmatter written in 2-digits will be transformed,
+       * other dates written in single-digit, such as `2020-1-1` will be treated as string.
+       * Some browsers (e.g. Safari) don't support this format.
+       */
       sorter: (prev: VuePressPage, next: VuePressPage) => {
-        const prevTime = new Date(prev.frontmatter.date).getTime();
-        const nextTime = new Date(next.frontmatter.date).getTime();
+        const prevTime = new Date(
+          prev.frontmatter.date.replace(/\-/g, '/')
+        ).getTime();
+        const nextTime = new Date(
+          next.frontmatter.date.replace(/\-/g, '/')
+        ).getTime();
         return prevTime - nextTime > 0 ? -1 : 1;
       },
     },


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**



Because only the dates in frontmatter written in 2-digits will be transformed, other dates written in single-digit, such as `2020-1-1` will be treated as string. Some browsers (e.g. Safari) don't support this format.

Relevant issue: vuejs/vuepress#2097

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

If changing the UI of default theme, please provide the **before/after** screenshot:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

You have tested in the following browsers: (Providing a detailed version will be better.)

- [x] Chrome
- [ ] Firefox
- [x] Safari
- [ ] Edge
- [ ] IE

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature
- [ ] Related documents have been updated
- [ ] Related tests have been updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
