### PR TITLE
docs: make ease to understand how to use getPaginationPageTitle

### DIFF
--- a/docs/pagination/README.md
+++ b/docs/pagination/README.md
@@ -88,12 +88,12 @@ A function to get the title of pagination page dynamically:
 ```js
 // directories
 function getPaginationPageTitle (pageNumber) {
-  return `Page ${pageNumber} | ${entryTitle}`
+  return `Page ${pageNumber} | Directory title`
 }
 
 // frontmatters
 function getPaginationPageTitle (pageNumber, key) {
-  return `Page ${pageNumber} - ${key} | ${entryTitle}`
+  return `Page ${pageNumber} - ${key} | Frontmatter title`
 }
 ```
 


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**

I make ease to understand how to use `getPaginationPageTitle` option.

We cannot use `${entryTitle}` in our own callback function. Using `${entryTitle}` in our callback causes build error `ReferenceError: entryTitle is not defined`.

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [x] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

If changing the UI of default theme, please provide the **before/after** screenshot:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

You have tested in the following browsers: (Providing a detailed version will be better.)

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
- [ ] IE

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature
- [ ] Related documents have been updated
- [ ] Related tests have been updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
